### PR TITLE
Fix/css for settings

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://paystack.com/demo
 Tags: paystack, recurrent payments, nigeria, mastercard, visa, target, Naira, payments, verve, donation, church, NGO, form, contact form 7, form
 Requires at least: 3.1
 Tested up to: 4.9.7
-Stable tag: 3.0.1
+Stable tag: 3.0.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -92,6 +92,8 @@ Yes you can! Join in on our [GitHub repository](https://github.com/PaystackHQ/wo
 
 
 == Changelog ==
+= 3.0.2 =
+* Fix CSS for API Settings page.
 = 3.0.0 =
 * Add a panel for charging convenience fee
 * Remove bug where plugin was causing a padding on sites

--- a/admin/class-paystack-forms-admin.php
+++ b/admin/class-paystack-forms-admin.php
@@ -664,12 +664,13 @@ class Kkd_Pff_Paystack_Admin
                 if($post->post_type == 'revision' ) { return; // Don't store custom data twice
                 }
                 $value = implode(',', (array)$value); // If $value is an array, make it a CSV (unlikely)
-                if(get_post_meta($post->ID, $key, false)) { // If the custom field already has a value
+                if (get_post_meta($post->ID, $key, false)) { // If the custom field already has a value
                     update_post_meta($post->ID, $key, $value);
                 } else { // If the custom field doesn't have a value
                     add_post_meta($post->ID, $key, $value);
                 }
-                if(!$value) { delete_post_meta($post->ID, $key); // Delete if blank
+                if (!$value) { 
+                    delete_post_meta($post->ID, $key); // Delete if blank
                 }
             }
 
@@ -679,7 +680,7 @@ class Kkd_Pff_Paystack_Admin
 
     public function enqueue_styles($hook) 
     {
-        if ($hook != 'toplevel_page_submissions') {
+        if ($hook != 'toplevel_page_submissions' && $hook != 'paystack_form_page_class-paystack-forms-admin') {
             return;
         }
         wp_enqueue_style($this->plugin_name, plugin_dir_url(__FILE__) . 'css/paystack-forms-admin.css', array(), $this->version, 'all');

--- a/paystack-forms.php
+++ b/paystack-forms.php
@@ -3,7 +3,7 @@
   Plugin Name:  Payment Forms for Paystack
   Plugin URI:   https://github.com/PaystackHQ/Wordpress-Payment-forms-for-Paystack
   Description:  Payment Forms for Paystack allows you create forms that will be used to bill clients for goods and services via Paystack.
-  Version:      3.0.1
+  Version:      3.0.2
   Author:       Paystack
   Author URI:   http://paystack.com
   License:      GPL-2.0+


### PR DESCRIPTION
In previous release, CSS was made to only affect certain pages on the plugin so as not create style conflicts (issues where some admin page are not displayed properly).

This Settings page was not included among the pages where the CSS should be applied. This PR fixes it.